### PR TITLE
Fix $DIR_BUILD/run/ directory is not created

### DIFF
--- a/_start.sh
+++ b/_start.sh
@@ -56,6 +56,7 @@ if [ $ret -ne 0 ]; then
 fi
 
 printf "\n===RUNNING - Saving data...===\n\n"
+mkdir -p "$DIR_BUILD/run/"
 echo "$DATA_PROCESS" > "$DIR_BUILD/run/timetables.json"
 
 printf "\n===DONE - Starting web server===\n\n"


### PR DESCRIPTION
The `$DIR_BUILD/run/` is not created inside the `_start.sh` script which results in the failure of creating `$DIR_BUILD/run/timetables.json` and thus the timetable generation result is thrown away.